### PR TITLE
Use NewDoc so that we can have more than one plant per userid

### DIFF
--- a/datalayer/controllers/plant/plant.go
+++ b/datalayer/controllers/plant/plant.go
@@ -23,7 +23,7 @@ func CreatePlant(plants *firestore.CollectionRef) gin.HandlerFunc {
 
 		log.Println("created plant", plant)
 
-		wr, err := plants.Doc(plant.UserID).Create(ctx, &plant)
+		wr, err := plants.NewDoc().Create(ctx, &plant)
 		if err != nil {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"code": http.StatusInternalServerError, "message": err.Error()})
 			return


### PR DESCRIPTION
Using the `UserID` as the doc ref means that you can only create one "Plant Doc" per `UserID`.

This creates a random UUID for the new doc so that you can have arbitrarily many plants per user. The best way to query for the plants (e.g. when you write the `GET` handler for the `/plants` route) will be to use the doc element `UserID` in a query  à la [these simple queries](https://firebase.google.com/docs/firestore/query-data/queries#simple_queries).